### PR TITLE
change from window.loaded to window.events.loaded

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -1273,7 +1273,7 @@ class App:
         else:
             authorisation_window = webview.create_window(window_title, request['permission_url'], on_top=True)
         setattr(authorisation_window, 'get_title', AuthorisationWindow.get_title)  # add missing get_title method
-        authorisation_window.loaded += self.authorisation_window_loaded
+        authorisation_window.events.loaded += self.authorisation_window_loaded
 
     def handle_authorisation_windows(self):
         if not sys.platform == 'darwin':


### PR DESCRIPTION
Hello! This is a small change that seems necessary to make the ```loaded``` event working properly, otherwise python bails out claiming that the attribute could not be set. In either case, AFAIK ```pywebview``` is going to deprecate the old style of binding to events in favor of ```events.loaded``.

Here is the traceback without this PR:

```
[pywebview] loaded event is deprecated and will be removed in 4.0. Use events.loaded instead
An error occurred when calling message handler
Traceback (most recent call last):
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_win32.py", line 402, in _dispatcher
    uMsg, lambda w, l: 0)(wParam, lParam) or 0)
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_win32.py", line 213, in _on_notify
    descriptors[index - 1](self)
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_base.py", line 306, in inner
    callback(self)
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_base.py", line 431, in __call__
    return self._action(icon, self)
  File "emailproxy.py", line 1252, in authorise_account
    self.create_authorisation_window(request)
  File "emailproxy.py", line 1276, in create_authorisation_window
    authorisation_window.loaded += self.authorisation_window_loaded
AttributeError: can't set attribute
[pywebview] loaded event is deprecated and will be removed in 4.0. Use events.loaded instead
An error occurred when calling message handler
Traceback (most recent call last):
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_win32.py", line 402, in _dispatcher
    uMsg, lambda w, l: 0)(wParam, lParam) or 0)
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_win32.py", line 213, in _on_notify
    descriptors[index - 1](self)
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_base.py", line 306, in inner
    callback(self)
  File "C:\Users\donald duck\AppData\Local\Programs\Python\Python37\lib\site-packages\pystray\_base.py", line 431, in __call__
    return self._action(icon, self)
  File "emailproxy.py", line 1252, in authorise_account
    self.create_authorisation_window(request)
  File "emailproxy.py", line 1276, in create_authorisation_window
    authorisation_window.loaded += self.authorisation_window_loaded
AttributeError: can't set attribute
```