### PR TITLE
Add authorisation via CLI

### DIFF
--- a/emailproxy.config
+++ b/emailproxy.config
@@ -65,6 +65,6 @@ client_secret = *** your client secret here ***
 permission_url = https://accounts.google.com/o/oauth2/auth
 token_url = https://oauth2.googleapis.com/token
 oauth2_scope = https://mail.google.com/
-redirect_uri = http://localhost
+redirect_uri = urn:ietf:wg:oauth:2.0:oob
 client_id = *** your client id here ***
 client_secret = *** your client secret here ***


### PR DESCRIPTION
Added command line authorization, new option is --manual-auth

This option prints the url to externally authenticate in a browser. After a successful authentication we will have the authorization code