### PR TITLE
Permit only valid IMAP tag characters rather than rejecting invalid

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -83,9 +83,10 @@ AUTHENTICATION_TIMEOUT = 600
 
 TOKEN_EXPIRY_MARGIN = 600  # seconds before its expiry to refresh the OAuth 2.0 token
 
-IMAP_AUTHENTICATION_REQUEST_MATCHER = re.compile(r'(?P<tag>[^\x00-\x1f\x20\x7f(){%*"\\+]+) (?P<command>(LOGIN|AUTHENTICATE)) (?P<flags>.*)',
+IMAP_TAG_PATTERN = r"^(?P<tag>[!#$&',-\[\]-z|}~]+)"  # https://ietf.org/rfc/rfc9051.html#name-formal-syntax
+IMAP_AUTHENTICATION_REQUEST_MATCHER = re.compile(IMAP_TAG_PATTERN + r' (?P<command>(LOGIN|AUTHENTICATE)) (?P<flags>.*)',
                                                  flags=re.IGNORECASE)
-IMAP_AUTHENTICATION_RESPONSE_MATCHER = re.compile(r'(?P<tag>[^\x00-\x1f\x20\x7f(){%*"\\+]+) OK AUTHENTICATE.*', flags=re.IGNORECASE)
+IMAP_AUTHENTICATION_RESPONSE_MATCHER = re.compile(IMAP_TAG_PATTERN + r' OK AUTHENTICATE.*', flags=re.IGNORECASE)
 
 REQUEST_QUEUE = queue.Queue()  # requests for authentication
 RESPONSE_QUEUE = queue.Queue()  # responses from client web view


### PR DESCRIPTION
@jryans I realised that even with the tweak I suggested to the new IMAP tag matcher, it still allows invalid tags (e.g., anything beyond the basic 128 ASCII characters). That is still better than what was used before, but I think it's worth fully matching the formal specification, so the version in this pull request takes an allowlist-based approach instead.

Could you test this change with your client that uses non-alphanumeric tags?