### PR TITLE
Set client credential flow access token to 'None'

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -411,8 +411,8 @@ class OAuth2Helper:
                                        OAuth2Helper.encrypt(fernet, response['refresh_token']))
                         AppConfig.save()
 
-                    elif access_token_expiry <= current_time:
-                        access_token = None  # avoid trying invalid tokens
+                    else:
+                        access_token = None  # avoid trying invalid (or soon to be) tokens
                 else:
                     access_token = OAuth2Helper.decrypt(fernet, access_token)
 


### PR DESCRIPTION
When the client credential access token expiry is within the expiry margin, set it to None.