### PR TITLE
Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:alpine as builder
+
+WORKDIR /email-oauth2-proxy
+
+COPY requirements-no-gui.txt requirements-no-gui.txt
+COPY emailproxy.py emailproxy.py
+
+RUN	apk add curl busybox-extras binutils && \
+	python -m pip install -r requirements-no-gui.txt && \
+	pip install -U pyinstaller && \
+	pyinstaller --onefile emailproxy.py
+
+FROM alpine:3.16 as app-base
+COPY --from=builder /email-oauth2-proxy/dist/emailproxy /usr/local/bin/emailproxy
+ENTRYPOINT ["/usr/local/bin/emailproxy", "--no-gui", "--local-server-auth"]
+CMD ["--config-file=/etc/emailproxy.config"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ On Windows the auto-start functionality is achieved via a shortcut in your user 
 
 On Linux this feature assumes that your system supports XDG Autostart. A Desktop Entry file `ac.robinson.email-oauth2-proxy.desktop` will be created in `~/.config/autostart/`. Use the proxy's menu option (or manually remove this file) to prevent it starting when you log in. It is also possible to run the proxy as a service (e.g., via `systemctl`) – see the `--no-gui` mode option above for more details.
 
+### Docker
+
+Assuming you already have a valid `emailproxy.config` file and now wish to run on a server by using Docker:
+
+1. Add `local_address = 0.0.0.0` to each listener section of the config file. Otherwise, emailproxy will listen to the Docker container's internal network interface and port publishing will not work.
+
+2. Place the config file somewhere on the host where Docker runs
+
+3. Run `docker build -t emailproxy:latest .` to build the image
+
+4. (Optionally) Push the image to a container registry, e.g. AWS ECR, by changing the tag used above and running `docker push myregistry.io/myuser/emailproxy:latest`
+
+5. Run `docker run --name emailproxy -d -p 1993:1993 -v /path/to/emailproxy-config:/etc/emailproxy.config emailproxy` to start the container (in this case, with only an IMAP listener at port 1993). Add further `-p` blocks as needed.
 
 ## Troubleshooting
 If you encounter problems using the proxy, enabling `Debug mode` from the menu or passing `--debug` as a script argument will print all client–proxy–server communication to your system log to help identify the issue. This will include all commands to and responses from the server (and also as a result the content of your email messages).


### PR DESCRIPTION
Hi,

I have created a Dockerfile that uses your recent addition of `pyinstaller` to produce a minmal-sized Docker image (~20 MB instead of ~140 MB).

Unfortunately I'm not experienced with GitHub Actions, but it should be possible for you to set up an automated Docker build of this image and a publish on Docker Hub.