### PR TITLE
Allow binding to IPv6 addresses

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -1696,7 +1696,7 @@ class OAuth2Proxy(asyncore.dispatcher):
 
     def start(self):
         Log.info('Starting', self.info_string())
-        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.create_socket(socket.AF_INET6, socket.SOCK_STREAM)
         self.set_reuse_addr()
         self.bind(self.local_address)
         self.listen(5)


### PR DESCRIPTION
Allow binding to IPv6.

The system I am on has IPv6 support and this works.  I'm not sure what the implications of such a simple change are with an IPv4 only system.  Do those even exist any more?  :smile:

OK, IPv6 is nowhere near ubiquitous, but aren't most modern systems dual-stack even when they don't have external/local network IPv6 support?