### PR TITLE
Add a Makefile and systemd configuration files to install system-wide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+ifeq ($(AS_USER),)
+prefix = /usr/local
+configdir = $(prefix)/etc
+libdir = $(prefix)/lib
+nmdispatcherdir = $(libdir)/NetworkManager/dispatcher.d
+systemddir = $(libdir)/systemd/system
+sysusersdir = $(libdir)/sysusers.d
+else
+prefix = $${XDG_CONFIG_DATA-$$HOME/.local}
+configdir = $${XDG_CONFIG_HOME-$$HOME/.config}
+libdir = $(prefix)
+systemddir = $(libdir)/systemd/user
+endif
+
+bindir = $(prefix)/bin
+
+INSTALL_FILE = install -m 644 -t
+INSTALL_BIN = install -m 755 -t
+INSTALL_DIR = install -m 755 -d
+
+install: install-bin install-config install-systemd
+install-bin:
+	$(INSTALL_DIR) $(INSTALL_ROOT)$(bindir)
+	$(INSTALL_BIN) $(INSTALL_ROOT)$(bindir) emailproxy.py
+
+install-config: $(INSTALL_ROOT)$(configdir)/emailproxy/emailproxy.config
+$(INSTALL_ROOT)$(configdir)/emailproxy/emailproxy.config:
+	$(INSTALL_DIR) $(INSTALL_ROOT)$(configdir)/emailproxy
+	$(INSTALL_FILE) $(INSTALL_ROOT)$(configdir)/emailproxy emailproxy.config
+
+install-systemd: emailproxy.service.in
+	$(INSTALL_DIR) $(INSTALL_ROOT)$(systemddir)
+	bindir=$(bindir) configdir=$(configdir); sed -e "s,@configdir@,$$configdir,g" -e "s,@bindir@,$$bindir,g" < $< > $(INSTALL_ROOT)$(systemddir)/emailproxy.service
+ifneq ($(sysusersdir),)
+	$(INSTALL_DIR) $(INSTALL_ROOT)$(sysusersdir)
+	$(INSTALL_FILE) $(INSTALL_ROOT)$(sysusersdir) sysusers.d/emailproxy.conf
+
+install: install-nm
+install-nm:
+	$(INSTALL_DIR) $(nminstalldir)
+	$(INSTALL_FILE) $(INSTALL_ROOT)$(nminstalldir) NetworkManager-dispatcher/emailproxy.sh
+endif
+
+.PHONY: install install-bin install-config install-nm install-systemd

--- a/emailproxy.service.in
+++ b/emailproxy.service.in
@@ -1,0 +1,21 @@
+# -*- conf -*-
+[Unit]
+Description=Service for the Microsoft365 OAuth2 proxying
+ConditionPathExists=@configdir@/emailproxy/emailproxy.config
+
+[Service]
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectProc=noaccess
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_INET
+UMask=077
+
+ConfigurationDirectory=emailproxy
+CacheDirectory=emailproxy
+CacheDirectoryMode=0700
+
+ExecStart=python3 @bindir@/emailproxy.py --no-gui --local-server-auth --config-file ${CONFIGURATION_DIRECTORY}/emailproxy.config --cache-store ${CACHE_DIRECTORY}/auth-cache
+Group=emailproxy
+User=emailproxy

--- a/sysusers.d/emailproxy.conf
+++ b/sysusers.d/emailproxy.conf
@@ -1,0 +1,2 @@
+#Type Name              ID      GECOS              Home directory	Shell
+u     emailproxy	-       "Email OAuth2 Proxy"


### PR DESCRIPTION
This will install by default to /usr/local, but you can override by running, for example:
  make prefix=/usr configdir=/etc

If you choose a prefix other than /usr or /usr/local, systemd won't find your files.

Some support is also there to install as a user service, with:
  make AS_USER=1