### PR TITLE
IPv6 binding with Dual Stack Support

### DIFF
--- a/emailproxy.config
+++ b/emailproxy.config
@@ -26,7 +26,9 @@ documentation = Local servers are specified as demonstrated below where, for exa
 	behalf (i.e., do not enable STARTTLS in your client). IMAP STARTTLS and POP STARTTLS are not currently supported.
 	
 	- If the property `local_address` is not specified, its value is assumed to be `localhost`. If required, this
-	parameter can be used to set an IP address or hostname for the proxy to listen on.
+	parameter can be used to set an IP address or hostname for the proxy to listen on. The IP address can be either
+	IPv4 or IPv6. You can also use a special case of `local_address = ::` which will enable acceptance of both IPv4 and
+	IPv6 connections (dual stack) on supported systems. Example shown in the section heading [SMTP-1587]
 	
 	Advanced server configuration:
 	- In the standard configuration the channel between your email client and the proxy is unencrypted. This is not
@@ -48,6 +50,7 @@ server_port = 995
 server_address = smtp.office365.com
 server_port = 587
 starttls = True
+local_address = ::
 
 [IMAP-2993]
 server_address = imap.gmail.com

--- a/emailproxy.config
+++ b/emailproxy.config
@@ -26,9 +26,9 @@ documentation = Local servers are specified as demonstrated below where, for exa
 	behalf (i.e., do not enable STARTTLS in your client). IMAP STARTTLS and POP STARTTLS are not currently supported.
 	
 	- If the property `local_address` is not specified, its value is assumed to be `localhost`. If required, this
-	parameter can be used to set an IP address or hostname for the proxy to listen on. The IP address can be either
-	IPv4 or IPv6. You can also use a special case of `local_address = ::` which will enable acceptance of both IPv4 and
-	IPv6 connections (dual stack) on supported systems. Example shown in the section heading [SMTP-1587]
+	parameter can be used to set an IP address or hostname for the proxy to listen on (either IPv4 or IPv6). If your
+	environment has dual-stack support, the proxy will attempt listen on both IPv4 and IPv6 simultaneously. To request
+	this for the local host, set `local_address = ::`.
 	
 	Advanced server configuration:
 	- In the standard configuration the channel between your email client and the proxy is unencrypted. This is not
@@ -50,7 +50,6 @@ server_port = 995
 server_address = smtp.office365.com
 server_port = 587
 starttls = True
-local_address = ::
 
 [IMAP-2993]
 server_address = imap.gmail.com

--- a/emailproxy.config
+++ b/emailproxy.config
@@ -25,10 +25,10 @@ documentation = Local servers are specified as demonstrated below where, for exa
 	(assumed to be False otherwise). With this parameter set, STARTTLS negotiation will be handled by the proxy on your
 	behalf (i.e., do not enable STARTTLS in your client). IMAP STARTTLS and POP STARTTLS are not currently supported.
 	
-	- If the property `local_address` is not specified, its value is assumed to be `localhost`. If required, this
-	parameter can be used to set an IP address or hostname for the proxy to listen on (either IPv4 or IPv6). If your
-	environment has dual-stack support, the proxy will attempt listen on both IPv4 and IPv6 simultaneously. To request
-	this for the local host, set `local_address = ::`.
+	- The `local_address` property can be used to set an IP address or hostname for the proxy to listen on (both IPv4
+	and IPv6 are supported). If not specified, this value is set to `localhost`. When running the proxy using python 3.8
+	or later, and in an environment with dual-stack support, the proxy will attempt to listen on both IPv4 and IPv6
+	hosts simultaneously. To request this for the local host, set `local_address = ::`.
 	
 	Advanced server configuration:
 	- In the standard configuration the channel between your email client and the proxy is unencrypted. This is not

--- a/emailproxy.py
+++ b/emailproxy.py
@@ -1729,8 +1729,13 @@ class OAuth2Proxy(asyncore.dispatcher):
 
     def create_socket(self, socket_family=socket.AF_INET, socket_type=socket.SOCK_STREAM):
         new_socket = socket.socket(socket_family, socket_type)
+        # Workaround for bug in Windows https://bugs.python.org/issue29515
+        if not hasattr(socket, "IPPROTO_IPV6"):
+            socket_level = 41
+        else:
+            socket_level = socket.IPPROTO_IPV6
         if socket_family == socket.AF_INET6:
-            new_socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            new_socket.setsockopt(socket_level, socket.IPV6_V6ONLY, 0)
         new_socket.setblocking(False)
 
         if self.ssl_connection:


### PR DESCRIPTION
This PR will allow binding to IPv6 addresses. It also has ability to accept both IPv4 and IPv6 connections by creating a Dual Stack bind on supported systems.