### PR TITLE
move fernet creation to helper method

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -572,7 +572,7 @@ class AppConfig:
 
 class Cryptographer:
     ITERATIONS = 870000  # taken from cryptography's suggestion of using Django's defaults
-    LEGACY_ITERATIONS = 100000
+    LEGACY_ITERATIONS = 100000  # fallback used when the config file does not specify the iteration count
 
     def __init__(self, config, username, password):
         """Creates a cryptographer which allows encrypting and decrypting sensitive information for this account,

--- a/emailproxy.py
+++ b/emailproxy.py
@@ -594,11 +594,12 @@ class Cryptographer:
 
         # try to read the user configured token iterations
         try:
-            iterations = int(config.get(username, 'token_iterations', fallback=self.LEGACY_ITERATIONS))
+            iterations = config.getint(username, 'token_iterations', fallback=self.LEGACY_ITERATIONS)
         except ValueError:
             iterations = self.LEGACY_ITERATIONS
 
-        # the first fernet is the primary fernet so sort the iterations count descending
+        # with MultiFernet each fernet is tried in order to decrypt a value, but encryption always uses the first fernet
+        # so sort the iterations count descending.
         self._iterations_options = sorted({self.ITERATIONS, iterations, self.LEGACY_ITERATIONS}, reverse=True)
 
         # generate encrypter/decrypter based on the password and a random salt

--- a/requirements-no-gui.txt
+++ b/requirements-no-gui.txt
@@ -1,7 +1,7 @@
 # this file contains the proxy's core dependencies beyond inbuilt python packages
 # note that to use this file instead of the default requirements.txt you *must* pass the `--no-gui` option when starting
 # the proxy - see the script's readme for further details
-cryptography
+cryptography>=2.2
 
 # provide the previously standard library module `asyncore`, removed in Python 3.12 (https://peps.python.org/pep-0594/)
 pyasyncore; python_version >= '3.12'


### PR DESCRIPTION
This change moves the fernet creation to a helper method in order to make it easier to either encrypt or decrypt values in the config/cache file. The motivation for this change is to make it easier to debug issues or to re-use OAuth tokens obtained outside the proxy.