### PR TITLE
allow importing as a script without GUI requirements installed

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -3130,6 +3130,10 @@ class App:
                 proxy.stop()
 
         if icon:
+            # work around a pystray issue with removing the macOS status bar icon when started from a parent script
+            if sys.platform == 'darwin':
+                # noinspection PyProtectedMember
+                icon._status_item.button().setImage_(None)
             icon.stop()
 
         # for the 'Start at login' option we need a callback to restart the script the first time this preference is
@@ -3142,6 +3146,8 @@ class App:
         # macOS Launch Agents need reloading when changed; unloading exits immediately so this must be our final action
         if sys.platform == 'darwin' and self.args.gui and self.macos_unload_plist_on_exit:
             self.macos_launchctl('unload')
+
+        EXITING = False  # to allow restarting when imported from parent scripts (or an interpreter)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change updates the script initialization to not fail on import errors, to finish without checking if `--no-gui` or `--external-auth` has been passed in the command-line, and instead raises an error when the application is initializing if running in GUI mode and the requirements are not met.

Minor changes also included:
- The `--no-gui` option is now stored as `gui` and defaults to `True` which changes comparisons to not be double negatives but retains the existing behavior.
- The App instance is allowed a single argument which is the command-line to parse, which allows starting the app with arguments from an import.