### PR TITLE
Add more or less standard header for the Python3 script

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+# vim: ts=4 sw=4 et ai si
 
 """A simple IMAP/POP/SMTP proxy that intercepts authenticate and login commands, transparently replacing them with OAuth
 2.0 authentication. Designed for apps/clients that don't support OAuth 2.0 but need to connect to modern servers."""


### PR DESCRIPTION
The script is using Python 3 interpreter and also it's good to have internal encoding defined. Taking all these into account, add a more or less standard header to the script.