### PR TITLE
Add support for OAUTH2 device flow (RFC 8628)

### DIFF
--- a/emailproxy.config
+++ b/emailproxy.config
@@ -155,6 +155,10 @@ documentation = Accounts are specified using your email address as the section h
 		attempts before the first valid login, pre-encrypting account entries is highly recommended. See the example
 		script at https://github.com/simonrob/email-oauth2-proxy/issues/61#issuecomment-1259110336.
 
+	- The proxy supports the device OAUTH2 flow (RFC 8628), which may better suit headless systems. With this flow
+	the proxy	receives authorization response directly from the service provider, therefore `redirect_uri` is not needed.
+	To use this flow set `oauth2_flow = device`.
+
 	Gmail customisation:
 	- The proxy supports the use of service accounts with Gmail for Google Workspace (note: normal Gmail accounts do not
 	support this method). To use this option, add an account entry as normal, but do not add a `permission_url` value
@@ -205,6 +209,13 @@ token_url = https://login.microsoftonline.com/common/oauth2/v2.0/token
 oauth2_scope = https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/POP.AccessAsUser.All https://outlook.office.com/SMTP.Send offline_access
 client_id = *** your client id here - note that as you are not the administrator of Hotmail.com / Outlook.com, you will need to reuse an existing client ID (see the proxy's readme) ***
 redirect_uri = https://localhost
+
+[your.free.outlook.or.hotmail.address.accessed.from.headless.system@outlook.com]
+permission_url = https://login.microsoftonline.com/common/oauth2/v2.0/devicecode
+token_url = https://login.microsoftonline.com/common/oauth2/v2.0/token
+oauth2_scope = https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/POP.AccessAsUser.All https://outlook.office.com/SMTP.Send offline_access
+client_id = *** your client id here - note that as you are not the administrator of Hotmail.com / Outlook.com, you will need to reuse an existing client ID (see the proxy's readme) ***
+oauth2_flow = device
 
 [your.email@gmail.com]
 permission_url = https://accounts.google.com/o/oauth2/auth


### PR DESCRIPTION
Hi! Thank you for the great tool!

Could you please take a look at this PR?

## Description

This PR adds support for OAUTH2 device flow:
- RFC: https://datatracker.ietf.org/doc/html/rfc8628
- Microsoft: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code

Device flow is particularly useful on headless systems, as it does not require usage of the redirect URL.

I successfully tested this PR with a free Microsoft account (`outlook.com`), and own application `client_id`.
The application (`client_id`) must be explicitly allowed to use the device flow in the Azure console.

## Implementation

The following properties are introduced into the request propagated from OAUTH2 to the main app:
- `need_response`: A boolean specifying the flow implies a response from a user to be provided to the proxy in order to retrieve the tokens. It is `false` for device flow, and `true` for others.
- `user_code`: A (short) string, which should be provided to the user for authentication at the service provider. User should manually enter it at the provider's web page.

The following changes are done to the UI, both graphical and console:
- external auth: the user code is printed to the console together with the verification URI.
- local server auth: the user code is printed to the console together with the verification URI.
- icon: the user code is added to the title of the authorization window.

## QA

I tested the proxy on Linux systems, in container and on desktop.
The following test cases are successful:
- external auth: the verification URI and user code are printed to the console.
- local server auth: the verification URI and user code are printed to the console.

**Attention!** On my systems I cannot make GUI work at all (even without my changes). The icon in the tray is always frozen, without notifications, and without context menu.
Therefore I cannot validate that the changes are correct for GUI interaction.