### PR TITLE
Add support for external authentication programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,70 @@ In no-GUI mode this option allows you to authenticate accounts entirely external
 You should ignore any browser error message that is shown (e.g., `unable to connect`); the important part is the URL itself.
 This argument is identical to enabling external authorisation mode from the `Authorise account` submenu of the proxy's menu bar icon.
 
+- `--external-auth-program` configures the proxy to execute an external program for authentication. This option is intended for usage on headless systems without an interactive user interface.
+The parameters required for the authentication are passed to the external program via standard input stream and the result is expected from the standard output stream. Input and output parameters should be encoded as JSON objects.
+The external program should report errors to the standard error stream.
+With the device authorisation grant (DAG) flow no output from the external program is expected.
+
+JSON scheme for the input authentication parameters:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "E-Mail OAUTH2 Proxy External Auth Program Input",
+  "type": "object",
+  "properties": {
+    "username": {
+      "description": "Username for the account to be authenticated",
+      "type": "string"
+    },
+    "permission_url": {
+      "description": "URL to be called for authentication",
+      "type": "string"
+    },
+    "redirect_uri": {
+      "description": "Expected redirect URI from the authentication server",
+      "type": "string"
+    },
+    "user_code": {
+      "description": "User code to be presented to the authentication server",
+      "type": "string"
+    },
+    "timeout": {
+      "description": "Timeout for the authentication process in seconds",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "username",
+    "permission_url",
+    "timeout"
+  ]
+}
+```
+
+After authentication attempt the external program should print the result as JSON object to the standard output. This output is optional for the device authorisation grant flow.
+JSON scheme for the external authentication program output:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "E-Mail OAUTH2 Proxy External Auth Program Result",
+  "type": "object",
+  "properties": {
+    "response_url": {
+      "description": "Response URL from the authentication server",
+      "type": "string"
+    }
+  },
+  "required": [
+  ]
+}
+```
+
+An example of an external authentication program for DAG flow is `gotifier` script, located within `external-auth-program/gotifier` directory.
+In order to use `gotifier` script, check `gotifier.conf` file for additional required configuration. It can be passed to the proxy command line as follows: `--external-auth-program=external-auth-program/gotifier/gotifier`.
+
 - `--local-server-auth` is similar to `--external-auth`, but instead instructs the proxy to temporarily start an internal web server to receive authentication responses.
 The `--external-auth` option is ignored in this mode.
 To authorise your account, visit the link that is provided, authenticate, and proceed until you are presented with a success webpage from the proxy.

--- a/external-auth-program/gotifier/gotifier
+++ b/external-auth-program/gotifier/gotifier
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# This script sends the provided authentication material to the remote gotify server.
+#
+# Notifications via gotify may be a suitable solution for device authorisation grant scenarios,
+# when the E-Mail OAUTH2 Proxy is running on a headless server.
+#
+# To use this script configure the required parameters as specified in `gotifier.conf` file.
+#
+# The E-Mail OAUTH2 Proxy can be configured to use this script with the `--external-auth-program` option.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/gotifier.conf"
+
+function die() {
+    echo "$1" 1>&2
+    exit 1
+}
+
+# Check requirements
+which curl >/dev/null || die "curl not found"
+which jq >/dev/null || die "jq not found"
+which sed >/dev/null || die "sed not found"
+
+function json_escape() {
+    jq -raRs . </dev/stdin | sed 's/^"//' | sed 's/\n"$//' | sed 's/"$//'
+}
+
+function json_field() {
+    jq -r ".$1 | select(.)" </dev/stdin
+}
+
+# Read input JSON into a variable
+INPUT="$(jq -Rrs . </dev/stdin)"
+
+USER_NAME="$(echo -n "${INPUT}" | json_field username)"
+OAUTH_URL="$(echo -n "${INPUT}" | json_field permission_url)"
+OAUTH_USER_CODE="$(echo -n "${INPUT}" | json_field user_code)"
+
+MESSAGE="Click [here](${OAUTH_URL}) to sign in as \`${USER_NAME}\`."
+
+if [[ -n "${OAUTH_USER_CODE}" ]]; then
+    MESSAGE="${MESSAGE}
+You may need the code: **${OAUTH_USER_CODE}**"
+fi
+
+GOTIFY_MESSAGE="{\
+  \"extras\": {\
+    \"client::display\": {\
+        \"contentType\": \"text/markdown\"\
+    }\
+  },\
+  \"message\": \"$(echo -n "${MESSAGE}" | json_escape)\",\
+  \"priority\": 9,\
+  \"title\": \"E-Mail OAUTH2 Sign-In Required\"\
+}"
+
+curl -s --fail-with-body "${GOTIFY_HOST}/message" \
+    -H "X-Gotify-Key: ${GOTIFY_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -X POST --data \
+    "$(echo -n "${GOTIFY_MESSAGE}" | jq -cr .)" 1>&2

--- a/external-auth-program/gotifier/gotifier-test
+++ b/external-auth-program/gotifier/gotifier-test
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This is a test script for verification of the `gotifier.conf` configuration.
+#
+# Configure the required parameters as specified in `gotifier.conf` file,
+# and run this script to check whether the messages are properly delivered to the gotify server.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+echo '{"username": "name.surname@test.com", "permission_url": "https://google.com", "timeout": 600, "user_code": "ABCDE"}' |
+  "${SCRIPT_DIR}/gotifier"
+
+echo '{"username": "name.surname@test.com", "permission_url": "https://microsoft.com", "timeout": 600}' |
+  "${SCRIPT_DIR}/gotifier"

--- a/external-auth-program/gotifier/gotifier.conf
+++ b/external-auth-program/gotifier/gotifier.conf
@@ -1,0 +1,10 @@
+# This file contains configuration for accessing gotify server.
+#
+# Any option below may be specified either within this file, or as an environment variable.
+
+# Host name running gotify server.
+# Use secure connection (https) to avoid interception of the authentication material.
+#GOTIFY_HOST="https://your.gotify.server"
+
+# Secret token for the gotify server.
+#GOTIFY_TOKEN="your gotify token"


### PR DESCRIPTION
Hi! Could you please take a look?

This PR adds a feature of delegation of the authentication process to an external program of user choice. This functionality improves the script usability when then EMail proxy is running on a headless server.

The PR includes a working example of a script implementing the authentication process for Device Authorisation Grant flow by sending the parameters to a [gotify](https://github.com/gotify/server) server specified by user. The example script can be configured via environment variables or by editing the included config file.

For the communication mechanism between the proxy and the script, the standard input and output streams are being used with the data encoded in JSON format. The `stdin`/`stdout` were selected instead of direct program arguments to mitigate possible size limit of the command line argument length for authentication URLs. According to POSIX, the command line argument minimum size is 4096 bytes (`xargs --show-limits`). 