### PR TITLE
Fix __package_version__ attr literal evaluation.

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -6,8 +6,8 @@
 __author__ = 'Simon Robinson'
 __copyright__ = 'Copyright (c) 2024 Simon Robinson'
 __license__ = 'Apache 2.0'
-__version__ = '2024-11-13'  # ISO 8601 (YYYY-MM-DD)
-__package_version__ = '.'.join([str(int(i)) for i in __version__.split('-')])  # for pyproject.toml usage only
+__package_version__ = '2024.11.13'  # for pyproject.toml usage only, needs to be ast.literal_eval() compatible
+__version__ = '-'.join(f"{int(part):02}" for part in __package_version__.split('.'))  # ISO 8601 (YYYY-MM-DD)
 
 import abc
 import argparse

--- a/emailproxy.py
+++ b/emailproxy.py
@@ -6,8 +6,8 @@
 __author__ = 'Simon Robinson'
 __copyright__ = 'Copyright (c) 2024 Simon Robinson'
 __license__ = 'Apache 2.0'
-__package_version__ = '2024.11.13'  # for pyproject.toml usage only, needs to be ast.literal_eval() compatible
-__version__ = '-'.join(f"{int(part):02}" for part in __package_version__.split('.'))  # ISO 8601 (YYYY-MM-DD)
+__package_version__ = '2024.11.13'  # for pyproject.toml usage only - needs to be ast.literal_eval() compatible
+__version__ = '-'.join('%02d' % int(part) for part in __package_version__.split('.'))  # ISO 8601 (YYYY-MM-DD)
 
 import abc
 import argparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "pyasyncore; python_version >= '3.12'", "cryptography"] # core requirements are needed for version detection when building for PyPI, which requires importing (but not running) the script on `ubuntu-latest`
+requires = ["setuptools>=62.6.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Dynamic metadata should be compatible with `ast.literal_eval()` so that import fallback is not needed. It's important to avoid the import fallback as that pulls in a number of unnecessary build dependencies.

See:
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata