### PR TITLE
Added Nuitka artifacts via gh-actions

### DIFF
--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -1,0 +1,76 @@
+name: Add Nuitka assets to latest release
+
+on:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  get_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.latest_tag.outputs.tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - id: latest_tag
+        run: |
+          git fetch -a
+          echo "tag=$(git tag --sort -committerdate | head -n 1)" >> $GITHUB_OUTPUT
+
+  build:
+    needs: get_tag
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          python -m pip install -r requirements-core.txt -r requirements-gui.txt nuitka
+          python -m pip install certifi
+          python -m pip install zstandard ordered-set
+          python -m pip install boto3 requests google-auth
+          python -m pip install imageio
+
+      - if: runner.os == 'macOS'
+        run: |
+            python -m nuitka --standalone --onefile --include-plugin-directory=. --include-package=timeago.locales.en_short --include-package=certifi --include-package=boto3 --include-package=requests --include-package=google --macos-create-app-bundle --macos-app-icon=icon.png --assume-yes-for-downloads --output-dir=dist emailproxy.py
+            rm -rf dist/emailproxy.build dist/emailproxy.dist dist/emailproxy.onefile-build
+      - if: runner.os == 'Windows'
+        run: |
+            python -m nuitka --standalone --onefile --include-plugin-directory=. --include-package=timeago.locales.en_short --include-package=certifi --include-package=boto3 --include-package=requests --include-package=google --windows-icon-from-ico=icon.png --assume-yes-for-downloads  --output-dir=dist emailproxy.py
+            Remove-Item -Path "dist/emailproxy.build","dist/emailproxy.dist","dist/emailproxy.onefile-build" -Recurse -Force
+
+      - run: |
+          move LICENSE . 2> nul || { shopt -s expand_aliases; alias move=mv; }
+          move LICENSE dist/
+          move README.md dist/
+          move emailproxy.config dist/
+          echo 'This binary distribution is automatically created for each Email OAuth 2.0 Proxy release, ' >> _.txt
+          echo 'but is not tested, and is not officially supported. Using the main emailproxy.py script ' >> _.txt
+          echo 'directly is recommended for best results: https://github.com/simonrob/email-oauth2-proxy/' >> _.txt
+          move _.txt dist/GettingStarted.txt
+
+      - uses: thedoctor0/zip-release@0.7.6
+        with:
+          type: zip
+          directory: dist/
+          filename: emailproxy-${{ needs.get_tag.outputs.output }}_nuitka-${{ runner.os }}.zip
+
+      - uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: dist/*.zip
+          update_latest_release: true


### PR DESCRIPTION
As our company's AV did always flag the pyinstaller version (as also noted in releases text and several discussions) and it doesn't quite fit our environment to run venvs barebone, I decided to add Nuitka compilation. ([Nuitka](https://nuitka.net/) converts python code to C/C++ and then compiles it, which makes the release standalone.)
I'd appreciate it, if you would give me feedback and if possible merge my changes into the main repo. I was not quite sure what the relationship between main and build is, but as the workflow files are in build, I worked on this branch. (It should be able to be merged into main without any conflicts.)

My changes:
- setup of nuitka.yml workflow
- modification of emailproxy.py to ignore version checks when running as Nuitka
- tested Nuitka artifact (only windows testing was possible, but should also work on macos; I tested the default behaviour used in our use case)

see for artifacts: https://github.com/sommerf-lf/email-oauth2-proxy/releases/tag/build-1fcb1933
- [emailproxy-2024-11-11_nuitka-macOS.zip](https://github.com/sommerf-lf/email-oauth2-proxy/releases/download/build-1fcb1933/emailproxy-2024-11-11_nuitka-macOS.zip)

- [emailproxy-2024-11-11_nuitka-Windows.zip](https://github.com/sommerf-lf/email-oauth2-proxy/releases/download/build-1fcb1933/emailproxy-2024-11-11_nuitka-Windows.zip)


![image](https://github.com/user-attachments/assets/86e7b3aa-c13e-4d9f-b256-72e1e148480d)
