### PR TITLE
Support resource field for legacy ROPC flow; normalize expires_in handling

### DIFF
--- a/emailproxy.config
+++ b/emailproxy.config
@@ -153,8 +153,10 @@ documentation = Accounts are specified using your email address as the section h
 	2.0 flows (both currently only known to be available for Office 365). To use either of these flows, add an account
 	entry as normal, but do not add a `permission_url` value (it does not apply, and its absence signals to the proxy to
 	use the appropriate token retrieval mechanism). For CCG, set `oauth2_scope = https://outlook.office365.com/.default`
-	and `oauth2_flow = client_credentials`. For ROPCG, set `oauth2_flow = password` (and use a standard scope value or a resource value). An
-	example is given for both methods towards the end of the sample account entries below.
+	and `oauth2_flow = client_credentials`. For ROPCG, set `oauth2_flow = password` (and use a standard scope value).
+	If you are using Microsoft services delivered by a regional provider (such as 21Vianet) that uses a non-standard
+	ROPCG variant, remove the `oauth2_scope` value and instead use `oauth2_resource`. Examples are given for each of
+	these cases towards the end of the sample account entries below.
 
 		- WARNING: Please note that by default the CCG flow has essentially no local access control when creating new
 		accounts (no user consent is involved, so the proxy cannot validate login attempts unless an account entry
@@ -280,7 +282,7 @@ client_id = *** your client id here ***
 client_secret = *** your client secret here (remove this entire line if a secret is not required) ***
 
 [ropcg.flow.resource.configured.address@your-tenant.com]
-documentation = *** note: this is an advanced 21Vianet O365 account example with a legacy field; in most cases you want the version above instead ***
+documentation = *** note: this is an advanced O365 account example specific to providers that use a non-standard version of the ROPCG flow (such as 21Vianet); in most cases you want the version above instead ***
 token_url = https://login.partner.microsoftonline.cn/*** your tenant id here ***/oauth2/token
 oauth2_resource = https://partner.outlook.cn
 oauth2_flow = password

--- a/emailproxy.config
+++ b/emailproxy.config
@@ -153,7 +153,7 @@ documentation = Accounts are specified using your email address as the section h
 	2.0 flows (both currently only known to be available for Office 365). To use either of these flows, add an account
 	entry as normal, but do not add a `permission_url` value (it does not apply, and its absence signals to the proxy to
 	use the appropriate token retrieval mechanism). For CCG, set `oauth2_scope = https://outlook.office365.com/.default`
-	and `oauth2_flow = client_credentials`. For ROPCG, set `oauth2_flow = password` (and use a standard scope value). An
+	and `oauth2_flow = client_credentials`. For ROPCG, set `oauth2_flow = password` (and use a standard scope value or a resource value). An
 	example is given for both methods towards the end of the sample account entries below.
 
 		- WARNING: Please note that by default the CCG flow has essentially no local access control when creating new
@@ -271,10 +271,18 @@ oauth2_flow = client_credentials
 client_id = *** your client id here ***
 client_secret = *** your client secret here (remove this entire line if a secret is not required) ***
 
-[ropcg.flow.configured.address@your-tenant.com]
+[ropcg.flow.scope.configured.address@your-tenant.com]
 documentation = *** note: this is an advanced O365 account example; in most cases you want the version above instead ***
 token_url = https://login.microsoftonline.com/*** your tenant id here ***/oauth2/v2.0/token
 oauth2_scope = https://outlook.office365.com/IMAP.AccessAsUser.All https://outlook.office365.com/POP.AccessAsUser.All https://outlook.office365.com/SMTP.Send offline_access
+oauth2_flow = password
+client_id = *** your client id here ***
+client_secret = *** your client secret here (remove this entire line if a secret is not required) ***
+
+[ropcg.flow.resource.configured.address@your-tenant.com]
+documentation = *** note: this is an advanced 21Vianet O365 account example with a legacy field; in most cases you want the version above instead ***
+token_url = https://login.partner.microsoftonline.cn/*** your tenant id here ***/oauth2/token
+oauth2_resource = https://partner.outlook.cn
 oauth2_flow = password
 client_id = *** your client id here ***
 client_secret = *** your client secret here (remove this entire line if a secret is not required) ***

--- a/emailproxy.py
+++ b/emailproxy.py
@@ -752,8 +752,8 @@ class OAuth2Helper:
         jwt_key_path = AppConfig.get_option_with_catch_all_fallback(config, username, 'jwt_key_path')
 
         # because the proxy supports a wide range of OAuth 2.0 flows, in addition to the token_url we only mandate the
-        # core parameters that are required by all methods: oauth2_scope and client_id
-        if not (token_url and client_id and (oauth2_scope or oauth2_resource)):
+        # core parameters that are required by all methods: oauth2_scope (or, for legacy ROPCG, resource) and client_id
+        if not (token_url and client_id and ((oauth2_flow == 'password' and oauth2_resource) or oauth2_scope)):
             Log.error('Proxy config file entry incomplete for account', username, '- aborting login')
             return (False, '%s: Incomplete config file entry found for account %s - please make sure all required '
                            'fields are added (at least token_url, oauth2_scope and client_id)' % (APP_NAME, username))

--- a/emailproxy.py
+++ b/emailproxy.py
@@ -1176,7 +1176,8 @@ class OAuth2Helper:
         authorisation_code and redirect_uri, returning a dict with 'access_token', 'expires_in', and 'refresh_token'
         on success, or throwing an exception on failure (e.g., HTTP 400)"""
 
-        if oauth2_flow == 'service_account':  # service accounts are slightly different, and are handled separately
+        # service accounts are slightly different, and are handled separately
+        if oauth2_flow == 'service_account':
             return OAuth2Helper.get_service_account_authorisation_token(client_id, client_secret, oauth2_scope,
                                                                         username)
 


### PR DESCRIPTION
This pull request enhances the OAuth 2.0 authentication flow in `emailproxy.py` by introducing support for `oauth2_resource` as an alternative to `oauth2_scope`, refining the handling of different OAuth 2.0 flows, and improving error handling and token normalization. Below are the key changes grouped by theme:

### Support for `oauth2_resource`:
* Added `oauth2_resource` as an optional configuration parameter retrieved via `AppConfig.get_option_with_catch_all_fallback`. This allows specifying a resource instead of a scope for OAuth 2.0 flows. (`[emailproxy.pyR742](diffhunk://#diff-8068eda2feddbc61595ced559aa73f8502813cf5cb1190a21e111ab1e8d19e88R742)`)
* Updated the validation logic to require either `oauth2_scope` or `oauth2_resource` when `token_url` and `client_id` are provided. (`[emailproxy.pyL755-R756](diffhunk://#diff-8068eda2feddbc61595ced559aa73f8502813cf5cb1190a21e111ab1e8d19e88L755-R756)`)
* Modified the `get_oauth2_authorisation_tokens` method to include `oauth2_resource` in the request parameters when applicable. (`[[1]](diffhunk://#diff-8068eda2feddbc61595ced559aa73f8502813cf5cb1190a21e111ab1e8d19e88L1169-R1176)`, `[[2]](diffhunk://#diff-8068eda2feddbc61595ced559aa73f8502813cf5cb1190a21e111ab1e8d19e88L1195-R1237)`)

### Refinements to OAuth 2.0 flow handling:
* Adjusted logic to set the default flow to `authorization_code` unless the flow is explicitly specified as `device` or `password`. (` [emailproxy.pyR887](diffhunk://#diff-8068eda2feddbc61595ced559aa73f8502813cf5cb1190a21e111ab1e8d19e88R887) `)

### Improved error handling and token normalization:
* Enhanced the token retrieval process to normalize the `expires_in` value to an integer, with error logging for invalid values. (`[emailproxy.pyL1195-R1237](diffhunk://#diff-8068eda2feddbc61595ced559aa73f8502813cf5cb1190a21e111ab1e8d19e88L1195-R1237)`)