### PR TITLE
Add helm example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See the [documentation and examples](https://github.com/simonrob/email-oauth2-pr
 Michael Stepner has created a [Terraform configuration](https://github.com/michaelstepner/email-oauth2-proxy-aws) that helps run this proxy on a lightweight cloud server (AWS EC2).
 Thiago Macieira has provided a [makefile and systemd configuration files](https://github.com/thiagomacieira/email-oauth2-proxy/tree/Add_a_Makefile_and_systemd_configuration_files_to_install_system_wide).
 For Docker, Moriah Morgan has an [example configuration](https://github.com/blacktirion/email-oauth2-proxy-docker).
+For Helm, Patrick Joyce has an [example chart](https://github.com/pjaudiomv/email-oauth2-proxy-helm).
 
 If you already use postfix, the [sasl-xoauth2](https://github.com/tarickb/sasl-xoauth2) plugin is probably a better solution than running this proxy.
 Similarly, if you use an application that is able to handle OAuth 2.0 tokens but just cannot retrieve them itself, then [pizauth](https://github.com/ltratt/pizauth), [mailctl](https://github.com/pdobsan/mailctl) or [oauth-helper-office-365](https://github.com/ahrex/oauth-helper-office-365) may be more appropriate.


### PR DESCRIPTION
I have created a helm chart for deploying the proxy to Kubernetes and thought it may be useful for others to use.

as a minimal example to test locally you could use minikube

```sh
minikube start --memory=4192 --cpus=4 --kubernetes-version=v1.30.0
helm repo add email-oauth2-proxy  https://pjaudiomv.github.io/email-oauth2-proxy-helm
helm repo update
kubectl create namespace email-oauth2-proxy
helm install email-oauth2-proxy email-oauth2-proxy/email-oauth2-proxy -f values.yaml
```

example values.yaml

```yaml
setupPod:
  enabled: true
config:
  DEBUG: true
  CACHE_STORE: /app/cache/credstore.config
configMap:
  enabled: true
  data: |
      [IMAP-2993]
      server_address = imap.gmail.com
      server_port = 993
      local_address = 0.0.0.0
    
      [incoming@gmail.org]
      permission_url = https://accounts.google.com/o/oauth2/auth
      redirect_uri = http://localhost/
      oauth2_scope = https://mail.google.com/
      token_url = https://oauth2.googleapis.com/token
      client_id = 167903-obfusicated-3hol.apps.googleusercontent.com
      client_secret = GOCSPX-Pet-rdummy-data-gPIOc
```

For my purposes, I get the proxy going in setup pod interactively and from there the proxy service pod uses the cache store persistent volume