### PR TITLE
Decline concurrent --local-server-auth requests instead of failing with EADDRINUSE

### DIFF
--- a/emailproxy.py
+++ b/emailproxy.py
@@ -714,6 +714,24 @@ class OAuth2Helper:
     class TokenRefreshError(Exception):
         pass
 
+    # usernames currently authenticating via start_redirection_receiver_server
+    _redirection_active_lock = threading.Lock()
+    _redirection_active = set()
+
+    @staticmethod
+    @contextlib.contextmanager
+    def reserve_redirection_slot(username):
+        """Yield True if we reserved the slot for username; False if a concurrent request already holds it."""
+        with OAuth2Helper._redirection_active_lock:
+            acquired = username not in OAuth2Helper._redirection_active
+            OAuth2Helper._redirection_active.add(username)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                with OAuth2Helper._redirection_active_lock:
+                    OAuth2Helper._redirection_active.discard(username)
+
     @staticmethod
     def get_oauth2_credentials(username, password, reload_remote_accounts=True):
         # noinspection GrazieInspection
@@ -1041,56 +1059,65 @@ class OAuth2Helper:
         redirect_listen_type = 'redirect_listen_address' if token_request['redirect_listen_address'] else 'redirect_uri'
         parsed_uri = urllib.parse.urlparse(token_request[redirect_listen_type])
         parsed_port = 80 if parsed_uri.port is None else parsed_uri.port
-        Log.debug('Local server auth mode (%s): starting server to listen for authentication response' %
-                  Log.format_host_port((parsed_uri.hostname, parsed_port)))
+        username = token_request['username']
 
-        class LoggingWSGIRequestHandler(wsgiref.simple_server.WSGIRequestHandler):
-            # pylint: disable-next=arguments-differ
-            def log_message(self, _format_string, *args):
-                Log.debug('Local server auth mode (%s): received authentication response' % Log.format_host_port(
-                    (parsed_uri.hostname, parsed_port)), *args)
-
-        class RedirectionReceiverWSGIApplication:
-            def __call__(self, environ, start_response):
-                start_response('200 OK', [('Content-type', 'text/html; charset=utf-8')])
-                token_request['response_url'] = '/'.join(token_request['redirect_uri'].split('/')[0:3]) + environ.get(
-                    'PATH_INFO') + '?' + environ.get('QUERY_STRING')
-                return [('<html><head><title>%s authentication complete (%s)</title><style type="text/css">body{margin:'
-                         '20px auto;line-height:1.3;font-family:sans-serif;font-size:16px;color:#444;padding:0 24px}'
-                         '</style></head><body><p>%s successfully authenticated account %s.</p><p>You can close this '
-                         'window.</p></body></html>' % ((APP_NAME, token_request['username']) * 2)).encode('utf-8')]
-
-        try:
-            wsgiref.simple_server.WSGIServer.allow_reuse_address = False
-            wsgiref.simple_server.WSGIServer.timeout = AUTHENTICATION_TIMEOUT
-            redirection_server = wsgiref.simple_server.make_server(str(parsed_uri.hostname), parsed_port,
-                                                                   RedirectionReceiverWSGIApplication(),
-                                                                   handler_class=LoggingWSGIRequestHandler)
-
-            Log.info('Please visit the following URL to authenticate account %s: %s' %
-                     (token_request['username'], token_request['permission_url']))
-            redirection_server.handle_request()
-            with contextlib.suppress(socket.error):
-                redirection_server.server_close()
-
-            if 'response_url' in token_request:
-                Log.debug('Local server auth mode (%s): closing local server and returning response' %
-                          Log.format_host_port((parsed_uri.hostname, parsed_port)), token_request['response_url'])
-            else:
-                # failed, likely because of an incorrect address (e.g., https vs http), but can also be due to timeout
+        with OAuth2Helper.reserve_redirection_slot(username) as acquired:
+            if not acquired:
+                # concurrent same-username AUTH would otherwise hit EADDRINUSE here
                 Log.info('Local server auth mode (%s):' % Log.format_host_port((parsed_uri.hostname, parsed_port)),
-                         'request failed - if this error reoccurs, please check `%s` for' % redirect_listen_type,
-                         token_request['username'], 'is not specified as `https` mistakenly. See the sample '
-                                                    'configuration file for documentation')
+                         'declining; retry after another in-flight authentication request completes for', username)
                 token_request['expired'] = True
+            else:
+                Log.debug('Local server auth mode (%s): starting server to listen for authentication response' %
+                          Log.format_host_port((parsed_uri.hostname, parsed_port)))
 
-        except socket.error as e:
-            Log.error('Local server auth mode (%s):' % Log.format_host_port((parsed_uri.hostname, parsed_port)),
-                      'unable to start local server. Please check that `%s` for %s is unique across accounts, '
-                      'specifies a port number, and is not already in use. See the documentation in the proxy\'s '
-                      'sample configuration file.' % (redirect_listen_type, token_request['username']),
-                      Log.error_string(e))
-            token_request['expired'] = True
+                class LoggingWSGIRequestHandler(wsgiref.simple_server.WSGIRequestHandler):
+                    # pylint: disable-next=arguments-differ
+                    def log_message(self, _format_string, *args):
+                        Log.debug('Local server auth mode (%s): received authentication response' % Log.format_host_port(
+                            (parsed_uri.hostname, parsed_port)), *args)
+
+                class RedirectionReceiverWSGIApplication:
+                    def __call__(self, environ, start_response):
+                        start_response('200 OK', [('Content-type', 'text/html; charset=utf-8')])
+                        token_request['response_url'] = '/'.join(token_request['redirect_uri'].split('/')[0:3]) + environ.get(
+                            'PATH_INFO') + '?' + environ.get('QUERY_STRING')
+                        return [('<html><head><title>%s authentication complete (%s)</title><style type="text/css">body{margin:'
+                                 '20px auto;line-height:1.3;font-family:sans-serif;font-size:16px;color:#444;padding:0 24px}'
+                                 '</style></head><body><p>%s successfully authenticated account %s.</p><p>You can close this '
+                                 'window.</p></body></html>' % ((APP_NAME, token_request['username']) * 2)).encode('utf-8')]
+
+                try:
+                    wsgiref.simple_server.WSGIServer.allow_reuse_address = False
+                    wsgiref.simple_server.WSGIServer.timeout = AUTHENTICATION_TIMEOUT
+                    redirection_server = wsgiref.simple_server.make_server(str(parsed_uri.hostname), parsed_port,
+                                                                           RedirectionReceiverWSGIApplication(),
+                                                                           handler_class=LoggingWSGIRequestHandler)
+
+                    Log.info('Please visit the following URL to authenticate account %s: %s' %
+                             (token_request['username'], token_request['permission_url']))
+                    redirection_server.handle_request()
+                    with contextlib.suppress(socket.error):
+                        redirection_server.server_close()
+
+                    if 'response_url' in token_request:
+                        Log.debug('Local server auth mode (%s): closing local server and returning response' %
+                                  Log.format_host_port((parsed_uri.hostname, parsed_port)), token_request['response_url'])
+                    else:
+                        # failed, likely because of an incorrect address (e.g., https vs http), but can also be due to timeout
+                        Log.info('Local server auth mode (%s):' % Log.format_host_port((parsed_uri.hostname, parsed_port)),
+                                 'request failed - if this error reoccurs, please check `%s` for' % redirect_listen_type,
+                                 token_request['username'], 'is not specified as `https` mistakenly. See the sample '
+                                                            'configuration file for documentation')
+                        token_request['expired'] = True
+
+                except socket.error as e:
+                    Log.error('Local server auth mode (%s):' % Log.format_host_port((parsed_uri.hostname, parsed_port)),
+                              'unable to start local server. Please check that `%s` for %s is unique across accounts, '
+                              'specifies a port number, and is not already in use. See the documentation in the proxy\'s '
+                              'sample configuration file.' % (redirect_listen_type, token_request['username']),
+                              Log.error_string(e))
+                    token_request['expired'] = True
 
         del token_request['local_server_auth']
         RESPONSE_QUEUE.put(token_request)


### PR DESCRIPTION
## Problem

When two authorisation requests arrive on the same listen address within `AUTHENTICATION_TIMEOUT` (default 600 s), `OAuth2Helper.start_redirection_receiver_server` spawns one thread per request. Each calls `wsgiref.simple_server.make_server(host, port, ...)` with `allow_reuse_address=False`. The second bind fails with `OSError(98, 'Address already in use')` and the proxy logs:

```
Local server auth mode (127.0.0.1:18080): unable to start local server. Please check that `redirect_listen_address` for user@example.com is unique across accounts, specifies a port number, and is not already in use. ... OSError(98, 'Address already in use')
```

For the **same-account** case (e.g., a mail client retrying SMTP while a health check probes AUTH, or two simultaneous client connections during the up-to-10-minute callback window) this message is misleading - the user's config is fine; it is a transient concurrency race.

For the **different-account** case the message is the correct diagnostic, as the config notes around `redirect_listen_address`:

> Please note that when using `--local-server-auth` the proxy will start/stop a new local server for each incoming authentication request, and does not explicitly handle repeated requests or multiple accounts authenticating using the same address. To avoid clashes, it is recommended that each account has a unique `redirect_uri` (or `redirect_listen_address`) value, for example by using a different port for each account.

This PR splits the two cases. Same-account duplicates are declined cleanly with an explicit message; different-account duplicates continue to surface the existing "unique across accounts" guidance unchanged.

## Reproduction

Single file, deterministic. Save next to `emailproxy.py`, then `python3 repro.py`.

```python
"""Reproduces the --local-server-auth concurrent bind collision.

Two authorisation requests on the same listen address within
AUTHENTICATION_TIMEOUT (default 600 s) each spawn a thread in
OAuth2Helper.start_redirection_receiver_server. The first binds the port
with allow_reuse_address=False; the second fails with OSError(98).

This PR splits the behaviour:
  - Same account on the same address: decline cleanly with a clear message.
  - Different account on the same address: fall through to the existing
    EADDRINUSE path (which has the correct "unique across accounts" message).

Run from a checkout of email-oauth2-proxy:
    python3 repro.py

Exit 0 if both cases match the expected post-fix behaviour, 1 otherwise.
"""
import sys
import threading
import time

import emailproxy


def make_request(host, port, username):
    return {
        'permission_url': f'http://{host}:{port}/auth',
        'redirect_uri': f'http://{host}:{port}',
        'redirect_listen_address': '',
        'username': username,
        'expired': False,
        'local_server_auth': True,
    }


def run_pair(host, port, username_a, username_b):
    messages = []
    for level in ('debug', 'info', 'error'):
        orig = getattr(emailproxy.Log, level)
        def capture(*args, _orig=orig):
            messages.append(' '.join(map(str, args)))
            _orig(*args)
        setattr(emailproxy.Log, level, capture)

    a_req = make_request(host, port, username_a)
    b_req = make_request(host, port, username_b)
    a = threading.Thread(target=emailproxy.OAuth2Helper.start_redirection_receiver_server,
                         args=(a_req,), name='A')
    b = threading.Thread(target=emailproxy.OAuth2Helper.start_redirection_receiver_server,
                         args=(b_req,), name='B')
    a.start()
    time.sleep(0.5)
    b.start()
    a.join()
    b.join()
    return messages


def main():
    emailproxy.Log.initialise()
    emailproxy.AUTHENTICATION_TIMEOUT = 2

    same = run_pair('127.0.0.1', 18181, 'a@example.com', 'a@example.com')
    same_eaddrinuse = any('Address already in use' in m for m in same)
    same_declined = any('declining;' in m for m in same)

    diff = run_pair('127.0.0.1', 18182, 'a@example.com', 'b@example.com')
    diff_eaddrinuse = any('Address already in use' in m for m in diff)
    diff_declined = any('declining;' in m for m in diff)

    print(file=sys.stderr)
    print(f'same-account:      EADDRINUSE={same_eaddrinuse} declined={same_declined}', file=sys.stderr)
    print(f'different-account: EADDRINUSE={diff_eaddrinuse} declined={diff_declined}', file=sys.stderr)

    ok = (not same_eaddrinuse and same_declined            # same: clean decline
          and diff_eaddrinuse and not diff_declined)       # different: original error path
    sys.exit(0 if ok else 1)


if __name__ == '__main__':
    main()
```

Without this PR (`exit 1`):

```
same-account:      EADDRINUSE=True  declined=False
different-account: EADDRINUSE=True  declined=False
```

With this PR (`exit 0`):

```
same-account:      EADDRINUSE=False declined=True
different-account: EADDRINUSE=True  declined=False
```

## Fix

`OAuth2Helper` now tracks the in-flight usernames in a class-level `set` guarded by a `threading.Lock` (the listen address is a function of the username via `AppConfig`, so the username alone is enough), exposed as a `@contextlib.contextmanager` so acquire/release are paired structurally. On entry:

- If the address is held by the **same** username → log "another authentication request is already in progress" + set `expired=True` + return (no bind attempted).
- If the address is held by a **different** username → fall through to the existing `make_server` call, which fails with `EADDRINUSE`. The existing `except socket.error` branch emits the "unique across accounts" diagnostic unchanged.
- If the address is free → record it and proceed; clear on `finally` only if we own the entry.

No behaviour change for the non-concurrent case. No new config knobs. ~30 lines added in one method.
